### PR TITLE
feat(ui): build checkpoint dialog edit ui, modify for 2 step record

### DIFF
--- a/lib/presentation/views/tracking_race_segment_screen/checkpoint_dialog.dart
+++ b/lib/presentation/views/tracking_race_segment_screen/checkpoint_dialog.dart
@@ -2,12 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:unitime/presentation/themes/theme.dart';
 import 'package:unitime/presentation/views/tracking_race_segment_screen/widgets/checkpoint_form.dart';
 
-Future<void> showDialogModifyCheckpoin({
+
+Future<void> showDialogModifyCheckpoint({
   required BuildContext context,
-  required String currentBib,
+  String? currentBib,
   required DateTime finishTime,
   required List<String> filterBIBs,
   required void Function(String newBib) onSaved,
+  bool isTwoStepRecord = false  
 }) async {
   await showDialog(
     context: context,
@@ -17,8 +19,9 @@ Future<void> showDialogModifyCheckpoin({
         appBar: AppBar(
           backgroundColor: UniColor.backGroundColor,
           automaticallyImplyLeading: false,
-          title: Text('Edit Finished BIB',
-          style: UniTextStyles.heading.copyWith(fontSize: 16, fontWeight: FontWeight.w500),
+          title: Text(
+            isTwoStepRecord ? 'Record BIB' : 'Edit Finished BIB',
+            style: UniTextStyles.heading.copyWith(fontSize: 16, fontWeight: FontWeight.w500),
           ),
           actions: [
             Padding(
@@ -44,6 +47,7 @@ Future<void> showDialogModifyCheckpoin({
             onSave: (newBib) {
               onSaved(newBib); // Save callback 
             },
+            isTwoStepRecord: isTwoStepRecord, // to check if edit / 2 step record bib
           ),
         ),
       ),

--- a/lib/presentation/views/tracking_race_segment_screen/checkpoint_dialog.dart
+++ b/lib/presentation/views/tracking_race_segment_screen/checkpoint_dialog.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:unitime/presentation/themes/theme.dart';
+import 'package:unitime/presentation/views/tracking_race_segment_screen/widgets/checkpoint_form.dart';
+
+Future<void> showDialogModifyCheckpoin({
+  required BuildContext context,
+  required String currentBib,
+  required DateTime finishTime,
+  required List<String> filterBIBs,
+  required void Function(String newBib) onSaved,
+}) async {
+  await showDialog(
+    context: context,
+    builder: (_) => Dialog.fullscreen(
+      child: Scaffold(
+        backgroundColor: UniColor.backGroundColor,
+        appBar: AppBar(
+          backgroundColor: UniColor.backGroundColor,
+          automaticallyImplyLeading: false,
+          title: Text('Edit Finished BIB',
+          style: UniTextStyles.heading.copyWith(fontSize: 16, fontWeight: FontWeight.w500),
+          ),
+          actions: [
+            Padding(
+              padding: const EdgeInsets.only(right: 12.0),
+              child: IconButton(
+                icon: const Icon(Icons.close, color: Colors.white),
+                onPressed: () => Navigator.pop(context),
+              ),
+            ),
+          ],
+
+          // leading: IconButton(
+          //   icon: const Icon(Icons.close),
+          //   onPressed: () => Navigator.pop(context),
+          // ),
+        ),
+        body: Padding(
+          padding: const EdgeInsets.all(UniSpacing.m),
+          child: CheckpointForm(
+            bibNumber: currentBib,
+            finishTime: finishTime,
+            availableBIBs: filterBIBs,
+            onSave: (newBib) {
+              onSaved(newBib); // Save callback 
+            },
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/presentation/views/tracking_race_segment_screen/test_checkpoint_ui.dart
+++ b/lib/presentation/views/tracking_race_segment_screen/test_checkpoint_ui.dart
@@ -9,21 +9,42 @@ class TestCheckpointScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('Checkpoint Test')),
       body: Center(
-        child: ElevatedButton(
-          child: const Text('Edit Checkpoint'),
-          onPressed: () {
-            showDialogModifyCheckpoin(
-              context: context,
-              currentBib: 'BIB001',
-              finishTime: DateTime.now(),
-              filterBIBs: ['BIB001', 'BIB002', 'BIB003'],
-              onSaved: (newBib) {
-                // For now, just print the result
-                debugPrint('Saved BIB: $newBib');
-                // debugPrint('Saved Note: $newNote');
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            // Edit Checkpoint Button
+            ElevatedButton(
+              child: const Text('Edit Checkpoint'),
+              onPressed: () {
+                showDialogModifyCheckpoint(
+                  context: context,
+                  currentBib: 'BIB001',
+                  finishTime: DateTime.now(),
+                  filterBIBs: ['BIB001', 'BIB002', 'BIB003'],
+                  onSaved: (newBib) {
+                    debugPrint('Saved BIB (Edit): $newBib');
+                  },
+                );
               },
-            );
-          },
+            ),
+            const SizedBox(height: 20),
+
+            // 2-Step Record Button
+            ElevatedButton(
+              child: const Text('2-Step Record'),
+              onPressed: () {
+                showDialogModifyCheckpoint(
+                  context: context,
+                  finishTime: DateTime.now(),
+                  filterBIBs: ['BIB004', 'BIB005', 'BIB006'],
+                  onSaved: (newBib) {
+                    debugPrint('Saved BIB (2-Step): $newBib');
+                  },
+                  isTwoStepRecord: true,
+                );
+              },
+            ),
+          ],
         ),
       ),
     );

--- a/lib/presentation/views/tracking_race_segment_screen/test_checkpoint_ui.dart
+++ b/lib/presentation/views/tracking_race_segment_screen/test_checkpoint_ui.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:unitime/presentation/views/tracking_race_segment_screen/checkpoint_dialog.dart';
+
+class TestCheckpointScreen extends StatelessWidget {
+  const TestCheckpointScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Checkpoint Test')),
+      body: Center(
+        child: ElevatedButton(
+          child: const Text('Edit Checkpoint'),
+          onPressed: () {
+            showDialogModifyCheckpoin(
+              context: context,
+              currentBib: 'BIB001',
+              finishTime: DateTime.now(),
+              filterBIBs: ['BIB001', 'BIB002', 'BIB003'],
+              onSaved: (newBib) {
+                // For now, just print the result
+                debugPrint('Saved BIB: $newBib');
+                // debugPrint('Saved Note: $newNote');
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/views/tracking_race_segment_screen/widgets/checkpoint_form.dart
+++ b/lib/presentation/views/tracking_race_segment_screen/widgets/checkpoint_form.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:unitime/presentation/themes/theme.dart';
+import 'package:unitime/presentation/widgets/UniButton.dart';
+
+
+class CheckpointForm extends StatefulWidget {
+  final String bibNumber;
+  final DateTime finishTime;
+  final List<String> availableBIBs;
+  final void Function(String newBib) onSave;
+
+  const CheckpointForm({
+    super.key,
+    required this.bibNumber,
+    required this.finishTime,
+    required this.availableBIBs,
+    required this.onSave,
+  });
+
+  @override
+  State<CheckpointForm> createState() => _CheckpointFormState();
+}
+
+class _CheckpointFormState extends State<CheckpointForm> {
+  late String selectedBib;
+  late DateTime finishTime;
+  late List<String> availableBIBs; 
+  // late String? note;
+
+  @override
+  void initState() {
+    super.initState();
+    selectedBib = widget.bibNumber;
+    finishTime = widget.finishTime;
+  }
+
+  void onSubmitForm() {
+    widget.onSave(selectedBib);
+    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        // BIB number dropdown
+        DropdownButtonFormField<String>(
+          value: selectedBib,
+          dropdownColor: UniColor.backGroundColor2,
+          decoration: InputDecoration(
+            labelText: "BIB Number",
+            labelStyle: UniTextStyles.body,
+          ),
+          items: availableBIBs.map((bib) {
+            return DropdownMenuItem(
+              value: bib,
+              child: Text(bib),
+            );
+          }).toList(),
+          onChanged: (value) {
+            if (value != null) {
+              setState(() {
+                selectedBib = value;
+              });
+            }
+          },
+          style: UniTextStyles.body,
+        ),
+        const SizedBox(height: UniSpacing.l),
+
+        // Finish Time
+        TextFormField(
+          initialValue: finishTime.toIso8601String(),
+          readOnly: true, // for only read
+          decoration: InputDecoration(
+            labelText: 'Finish Time',
+            labelStyle: UniTextStyles.body,
+          ),
+          style: UniTextStyles.body,
+        ),
+        const SizedBox(height: UniSpacing.m),
+
+        // // Optional Note
+        // TextFormField(
+        //   initialValue: note,
+        //   maxLines: 3,
+        //   decoration: InputDecoration(
+        //     labelText: 'Note (optional)',
+        //     hintText: 'Add comment for audit/fix',
+        //     labelStyle: UniTextStyles.body,
+        //   ),
+        //   style: UniTextStyles.body,
+        //   onChanged: (value) => note = value,
+
+        // ),
+        const SizedBox(height: UniSpacing.xl),
+
+        // Submit buttons section
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            // Cancel button
+            Expanded(
+              child: UniButton(
+                label: 'Cancel',
+                color: UniColor.grayDark,
+                onTrigger: () => Navigator.pop(context),
+              ),
+            ),
+            const SizedBox(width: UniSpacing.m),
+
+            // save/update button
+            Expanded(
+              child: UniButton(
+                label: 'Save',
+                color: UniColor.primary,
+                onTrigger: onSubmitForm,
+              ),
+            ),
+          ],
+        )
+      ],
+    );
+  }
+}


### PR DESCRIPTION
- Created CheckpointForm widget (BIB dropdown + finish time)
- Wrapped in fullscreen dialog via showDialogModifyCheckpoint
- Parameter passed in: bibNumber, finishTime, availableBIBs, onSave
- UI only — logic will be integrate later (via Provider/service)
- update form for assign bib as 2 step record, (not custom keypad just use simple keyboard for textfield)